### PR TITLE
Update image version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Follow these detailed steps to deploy the No-Code Architects Toolkit on Google C
   - Click **+ CREATE SERVICE**.
   - **Service Settings**:
     - **Container Image URL**:
-      - Enter `stephengpope/no-code-architects-toolkit:v1.0.1`.
+      - Enter `stephengpope/no-code-architects-toolkit:latest`.
     - **Service Name**:
       - Use the default or specify a name.
     - **Region**:


### PR DESCRIPTION
The previous version 'v1.0.1' is outdated, and most of the documentation is no longer relevant. Switching to 'latest' ensures compatibility with the current documentation and features.