### PR TITLE
echo "Stopping no-code-architects running Docker containers..."

### DIFF
--- a/local.sh
+++ b/local.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Stop all running Docker containers
-echo "Stopping all running Docker containers..."
-docker stop $(docker ps -aq)
+echo "Stopping no-code-architects running Docker containers..."
+docker stop $(docker ps -a --filter ancestor=no-code-architects-toolkit:testing --format="{{.ID}}")
 
 # Build the Docker image
 echo "Building Docker image..."


### PR DESCRIPTION
The stop should only stop the related container. This can cause issues with other services unrelated to the project.