### PR TITLE
sample_rate conversion with safe defaults

### DIFF
--- a/docs/media/transform/media_to_mp3.md
+++ b/docs/media/transform/media_to_mp3.md
@@ -22,6 +22,7 @@ POST /v1/media/transform/mp3
 - `webhook_url` (optional, string): The URL to receive a webhook notification upon completion.
 - `id` (optional, string): A unique identifier for the request.
 - `bitrate` (optional, string): The desired bitrate for the output MP3 file, in the format `<value>k` (e.g., `128k`). If not provided, defaults to `128k`.
+- `sample_rate` (optional, string): The desired sample rate for the output MP3 file, in the format `XXXXX` (e.g., `44100`). If not provided, it will use the sample rate of the input file.
 
 The `validate_payload` directive in the routes file enforces the following JSON schema for the request body:
 
@@ -32,7 +33,8 @@ The `validate_payload` directive in the routes file enforces the following JSON 
         "media_url": {"type": "string", "format": "uri"},
         "webhook_url": {"type": "string", "format": "uri"},
         "id": {"type": "string"},
-        "bitrate": {"type": "string", "pattern": "^[0-9]+k$"}
+        "bitrate": {"type": "string", "pattern": "^[0-9]+k$"},
+        "sample_rate": {"type": "string", "pattern": "^[0-9]{5}$"}
     },
     "required": ["media_url"],
     "additionalProperties": False
@@ -46,7 +48,8 @@ The `validate_payload` directive in the routes file enforces the following JSON 
     "media_url": "https://example.com/video.mp4",
     "webhook_url": "https://example.com/webhook",
     "id": "unique-request-id",
-    "bitrate": "192k"
+    "bitrate": "192k",
+    "sample_rate": "48000"
 }
 ```
 

--- a/routes/media_to_mp3.py
+++ b/routes/media_to_mp3.py
@@ -7,37 +7,46 @@ from services.authentication import authenticate
 from services.cloud_storage import upload_file
 import os
 
-convert_bp = Blueprint('convert', __name__)
+convert_bp = Blueprint("convert", __name__)
 logger = logging.getLogger(__name__)
 
-@convert_bp.route('/media-to-mp3', methods=['POST'])
+
+@convert_bp.route("/media-to-mp3", methods=["POST"])
 @authenticate
-@validate_payload({
-    "type": "object",
-    "properties": {
-        "media_url": {"type": "string", "format": "uri"},
-        "webhook_url": {"type": "string", "format": "uri"},
-        "id": {"type": "string"},
-        "bitrate": {"type": "string", "pattern": "^[0-9]+k$"}
-    },
-    "required": ["media_url"],
-    "additionalProperties": False
-})
+@validate_payload(
+    {
+        "type": "object",
+        "properties": {
+            "media_url": {"type": "string", "format": "uri"},
+            "webhook_url": {"type": "string", "format": "uri"},
+            "id": {"type": "string"},
+            "bitrate": {"type": "string", "pattern": "^[0-9]+k$"},
+            "sample_rate": {"type": "string", "pattern": "^[0-9]{5}$"},
+        },
+        "required": ["media_url"],
+        "additionalProperties": False,
+    }
+)
 @queue_task_wrapper(bypass_queue=False)
 def convert_media_to_mp3(job_id, data):
-    media_url = data['media_url']
-    webhook_url = data.get('webhook_url')
-    id = data.get('id')
-    bitrate = data.get('bitrate', '128k')
+    media_url = data["media_url"]
+    webhook_url = data.get("webhook_url")
+    id = data.get("id")
+    bitrate = data.get("bitrate", "128k")
+    sample_rate = data.get("sample_rate", None)
 
-    logger.info(f"Job {job_id}: Received media-to-mp3 request for media URL: {media_url}")
+    logger.info(
+        f"Job {job_id}: Received media-to-mp3 request for media URL: {media_url}"
+    )
 
     try:
-        output_file = process_conversion(media_url, job_id, bitrate)
+        output_file = process_conversion(media_url, job_id, bitrate, sample_rate)
         logger.info(f"Job {job_id}: Media conversion process completed successfully")
 
         cloud_url = upload_file(output_file)
-        logger.info(f"Job {job_id}: Converted media uploaded to cloud storage: {cloud_url}")
+        logger.info(
+            f"Job {job_id}: Converted media uploaded to cloud storage: {cloud_url}"
+        )
 
         return cloud_url, "/media-to-mp3", 200
 

--- a/routes/media_to_mp3.py
+++ b/routes/media_to_mp3.py
@@ -33,7 +33,7 @@ def convert_media_to_mp3(job_id, data):
     webhook_url = data.get("webhook_url")
     id = data.get("id")
     bitrate = data.get("bitrate", "128k")
-    sample_rate = data.get("sample_rate", None)
+    sample_rate = data.get("sample_rate")
 
     logger.info(
         f"Job {job_id}: Received media-to-mp3 request for media URL: {media_url}"

--- a/routes/v1/media/transform/media_to_mp3.py
+++ b/routes/v1/media/transform/media_to_mp3.py
@@ -7,37 +7,46 @@ from services.authentication import authenticate
 from services.cloud_storage import upload_file
 import os
 
-v1_media_transform_mp3_bp = Blueprint('v1_media_transform', __name__)
+v1_media_transform_mp3_bp = Blueprint("v1_media_transform", __name__)
 logger = logging.getLogger(__name__)
 
-@v1_media_transform_mp3_bp.route('/v1/media/transform/mp3', methods=['POST'])
+
+@v1_media_transform_mp3_bp.route("/v1/media/transform/mp3", methods=["POST"])
 @authenticate
-@validate_payload({
-    "type": "object",
-    "properties": {
-        "media_url": {"type": "string", "format": "uri"},
-        "webhook_url": {"type": "string", "format": "uri"},
-        "id": {"type": "string"},
-        "bitrate": {"type": "string", "pattern": "^[0-9]+k$"}
-    },
-    "required": ["media_url"],
-    "additionalProperties": False
-})
+@validate_payload(
+    {
+        "type": "object",
+        "properties": {
+            "media_url": {"type": "string", "format": "uri"},
+            "webhook_url": {"type": "string", "format": "uri"},
+            "id": {"type": "string"},
+            "bitrate": {"type": "string", "pattern": "^[0-9]+k$"},
+            "sample_rate": {"type": "string", "pattern": "^[0-9]{5}$"},
+        },
+        "required": ["media_url"],
+        "additionalProperties": False,
+    }
+)
 @queue_task_wrapper(bypass_queue=False)
 def convert_media_to_mp3(job_id, data):
-    media_url = data['media_url']
-    webhook_url = data.get('webhook_url')
-    id = data.get('id')
-    bitrate = data.get('bitrate', '128k')
+    media_url = data["media_url"]
+    webhook_url = data.get("webhook_url")
+    id = data.get("id")
+    bitrate = data.get("bitrate", "128k")
+    sample_rate = data.get("sample_rate")
 
-    logger.info(f"Job {job_id}: Received media-to-mp3 request for media URL: {media_url}")
+    logger.info(
+        f"Job {job_id}: Received media-to-mp3 request for media URL: {media_url}"
+    )
 
     try:
-        output_file = process_media_to_mp3(media_url, job_id, bitrate)
+        output_file = process_media_to_mp3(media_url, job_id, bitrate, sample_rate)
         logger.info(f"Job {job_id}: Media conversion process completed successfully")
 
         cloud_url = upload_file(output_file)
-        logger.info(f"Job {job_id}: Converted media uploaded to cloud storage: {cloud_url}")
+        logger.info(
+            f"Job {job_id}: Converted media uploaded to cloud storage: {cloud_url}"
+        )
 
         return cloud_url, "/v1/media/transform/mp3", 200
 

--- a/services/ffmpeg_toolkit.py
+++ b/services/ffmpeg_toolkit.py
@@ -6,18 +6,27 @@ from services.file_management import download_file
 # Set the default local storage directory
 STORAGE_PATH = "/tmp/"
 
-def process_conversion(media_url, job_id, bitrate='128k', webhook_url=None):
+
+def process_conversion(
+    media_url, job_id, bitrate="128k", sample_rate=None, webhook_url=None
+):
     """Convert media to MP3 format with specified bitrate."""
-    input_filename = download_file(media_url, os.path.join(STORAGE_PATH, f"{job_id}_input"))
+    input_filename = download_file(
+        media_url, os.path.join(STORAGE_PATH, f"{job_id}_input")
+    )
     output_filename = f"{job_id}.mp3"
     output_path = os.path.join(STORAGE_PATH, output_filename)
+    output_params = {"acodec": "libmp3lame", "audio_bitrate": bitrate}
+
+    # add sample_rate if specified
+    if sample_rate is not None:
+        output_params["ar"] = sample_rate
 
     try:
         # Convert media file to MP3 with specified bitrate
         (
-            ffmpeg
-            .input(input_filename)
-            .output(output_path, acodec='libmp3lame', audio_bitrate=bitrate)
+            ffmpeg.input(input_filename)
+            .output(output_path, **output_params)
             .overwrite_output()
             .run(capture_stdout=True, capture_stderr=True)
         )
@@ -26,13 +35,16 @@ def process_conversion(media_url, job_id, bitrate='128k', webhook_url=None):
 
         # Ensure the output file exists locally before attempting upload
         if not os.path.exists(output_path):
-            raise FileNotFoundError(f"Output file {output_path} does not exist after conversion.")
+            raise FileNotFoundError(
+                f"Output file {output_path} does not exist after conversion."
+            )
 
         return output_path
 
     except Exception as e:
         print(f"Conversion failed: {str(e)}")
         raise
+
 
 def process_video_combination(media_urls, job_id, webhook_url=None):
     """Combine multiple videos into one."""
@@ -43,37 +55,41 @@ def process_video_combination(media_urls, job_id, webhook_url=None):
     try:
         # Download all media files
         for i, media_item in enumerate(media_urls):
-            url = media_item['video_url']
-            input_filename = download_file(url, os.path.join(STORAGE_PATH, f"{job_id}_input_{i}"))
+            url = media_item["video_url"]
+            input_filename = download_file(
+                url, os.path.join(STORAGE_PATH, f"{job_id}_input_{i}")
+            )
             input_files.append(input_filename)
 
         # Generate an absolute path concat list file for FFmpeg
         concat_file_path = os.path.join(STORAGE_PATH, f"{job_id}_concat_list.txt")
-        with open(concat_file_path, 'w') as concat_file:
+        with open(concat_file_path, "w") as concat_file:
             for input_file in input_files:
                 # Write absolute paths to the concat list
                 concat_file.write(f"file '{os.path.abspath(input_file)}'\n")
 
         # Use the concat demuxer to concatenate the videos
         (
-            ffmpeg.input(concat_file_path, format='concat', safe=0).
-                output(output_path, c='copy').
-                run(overwrite_output=True)
+            ffmpeg.input(concat_file_path, format="concat", safe=0)
+            .output(output_path, c="copy")
+            .run(overwrite_output=True)
         )
 
         # Clean up input files
         for f in input_files:
             os.remove(f)
-            
+
         os.remove(concat_file_path)  # Remove the concat list file after the operation
 
         print(f"Video combination successful: {output_path}")
 
         # Check if the output file exists locally before upload
         if not os.path.exists(output_path):
-            raise FileNotFoundError(f"Output file {output_path} does not exist after combination.")
+            raise FileNotFoundError(
+                f"Output file {output_path} does not exist after combination."
+            )
 
         return output_path
     except Exception as e:
         print(f"Video combination failed: {str(e)}")
-        raise 
+        raise

--- a/services/v1/media/transform/media_to_mp3.py
+++ b/services/v1/media/transform/media_to_mp3.py
@@ -6,18 +6,27 @@ from services.file_management import download_file
 # Set the default local storage directory
 STORAGE_PATH = "/tmp/"
 
-def process_media_to_mp3(media_url, job_id, bitrate='128k', webhook_url=None):
+
+def process_media_to_mp3(
+    media_url, job_id, bitrate="128k", sample_rate=None, webhook_url=None
+):
     """Convert media to MP3 format with specified bitrate."""
-    input_filename = download_file(media_url, os.path.join(STORAGE_PATH, f"{job_id}_input"))
+    input_filename = download_file(
+        media_url, os.path.join(STORAGE_PATH, f"{job_id}_input")
+    )
     output_filename = f"{job_id}.mp3"
     output_path = os.path.join(STORAGE_PATH, output_filename)
+    output_args = {"acodec": "libmp3lame", "audio_bitrate": bitrate}
+
+    # Add sample_rate if specified
+    if sample_rate is not None:
+        output_args["ar"] = sample_rate
 
     try:
         # Convert media file to MP3 with specified bitrate
         (
-            ffmpeg
-            .input(input_filename)
-            .output(output_path, acodec='libmp3lame', audio_bitrate=bitrate)
+            ffmpeg.input(input_filename)
+            .output(output_path, **output_args)
             .overwrite_output()
             .run(capture_stdout=True, capture_stderr=True)
         )
@@ -26,13 +35,16 @@ def process_media_to_mp3(media_url, job_id, bitrate='128k', webhook_url=None):
 
         # Ensure the output file exists locally before attempting upload
         if not os.path.exists(output_path):
-            raise FileNotFoundError(f"Output file {output_path} does not exist after conversion.")
+            raise FileNotFoundError(
+                f"Output file {output_path} does not exist after conversion."
+            )
 
         return output_path
 
     except Exception as e:
         print(f"Conversion failed: {str(e)}")
         raise
+
 
 def process_video_combination(media_urls, job_id, webhook_url=None):
     """Combine multiple videos into one."""
@@ -43,37 +55,41 @@ def process_video_combination(media_urls, job_id, webhook_url=None):
     try:
         # Download all media files
         for i, media_item in enumerate(media_urls):
-            url = media_item['video_url']
-            input_filename = download_file(url, os.path.join(STORAGE_PATH, f"{job_id}_input_{i}"))
+            url = media_item["video_url"]
+            input_filename = download_file(
+                url, os.path.join(STORAGE_PATH, f"{job_id}_input_{i}")
+            )
             input_files.append(input_filename)
 
         # Generate an absolute path concat list file for FFmpeg
         concat_file_path = os.path.join(STORAGE_PATH, f"{job_id}_concat_list.txt")
-        with open(concat_file_path, 'w') as concat_file:
+        with open(concat_file_path, "w") as concat_file:
             for input_file in input_files:
                 # Write absolute paths to the concat list
                 concat_file.write(f"file '{os.path.abspath(input_file)}'\n")
 
         # Use the concat demuxer to concatenate the videos
         (
-            ffmpeg.input(concat_file_path, format='concat', safe=0).
-                output(output_path, c='copy').
-                run(overwrite_output=True)
+            ffmpeg.input(concat_file_path, format="concat", safe=0)
+            .output(output_path, c="copy")
+            .run(overwrite_output=True)
         )
 
         # Clean up input files
         for f in input_files:
             os.remove(f)
-            
+
         os.remove(concat_file_path)  # Remove the concat list file after the operation
 
         print(f"Video combination successful: {output_path}")
 
         # Check if the output file exists locally before upload
         if not os.path.exists(output_path):
-            raise FileNotFoundError(f"Output file {output_path} does not exist after combination.")
+            raise FileNotFoundError(
+                f"Output file {output_path} does not exist after combination."
+            )
 
         return output_path
     except Exception as e:
         print(f"Video combination failed: {str(e)}")
-        raise 
+        raise


### PR DESCRIPTION
This is my proposed implementation for sample rate, with the following details:

- use a string for the value, matching on "XXXXX" where it is exactly 5 digits
- default to `None` if not provided and then use this to keep the inbound clip sample rate instead
- changed the options input to kwargs parameter so we can add/remove the `--ar` flag if `sample_rate` is `None`
- updated docs

I wasn't clear on if we needed to update both `media_to_mp3.py` and `ffmpeg_toolkit.py` because they both look like they're in use. I decided that if we're implementing this, it should be implemented everywhere that does a transformation.

Some of the changes look noisier than they are because I have VSCode removing trailing whitespace on save and applying consistent formatting with Prettier (like double instead of single quotes, how multiline function calls are written, etc).