### PR TITLE
added env and code_url to /v1/code/execute/python

### DIFF
--- a/routes/v1/code/execute/execute_python.py
+++ b/routes/v1/code/execute/execute_python.py
@@ -25,6 +25,7 @@ import subprocess
 import tempfile
 import json
 import textwrap
+import requests
 
 v1_code_execute_bp = Blueprint('v1_code_execute', __name__)
 logger = logging.getLogger(__name__)
@@ -35,11 +36,17 @@ logger = logging.getLogger(__name__)
     "type": "object",
     "properties": {
         "code": {"type": "string"},
+        "code_url": {"type": "string", "format": "uri"},
+        "env": {"type": "object", "additionalProperties": {"type": ["string", "number", "boolean"]}},
         "timeout": {"type": "integer", "minimum": 1, "maximum": 300},
         "webhook_url": {"type": "string", "format": "uri"},
         "id": {"type": "string"}
     },
-    "required": ["code"],
+    "oneOf": [
+        {"required": ["code"]},
+        {"required": ["code_url"]}
+    ],
+    "not": {"required": ["code", "code_url"]},
     "additionalProperties": False
 })
 @queue_task_wrapper(bypass_queue=False)
@@ -47,9 +54,30 @@ def execute_python(job_id, data):
     logger.info(f"Job {job_id}: Received Python code execution request")
     
     try:
-        code = data['code']
+        if 'code' in data and 'code_url' in data:
+            return {"error": "Provide either 'code' or 'code_url', not both."}, '/v1/code/execute/python', 400
+        if 'code_url' in data:
+            MAX_CODE_SIZE = 1024**2  # 1MB
+            try:
+                resp = requests.get(data['code_url'], stream=True, timeout=10)
+                resp.raise_for_status()
+                content_length = resp.headers.get('Content-Length')
+                if content_length and int(content_length) > MAX_CODE_SIZE:
+                    return {"error": f"Code file too large (>{MAX_CODE_SIZE} bytes)"}, '/v1/code/execute/python', 400
+                code_chunks = []
+                total = 0
+                for chunk in resp.iter_content(4096):
+                    total += len(chunk)
+                    if total > MAX_CODE_SIZE:
+                        return {"error": f"Code file too large (>{MAX_CODE_SIZE} bytes) while downloading"}, '/v1/code/execute/python', 400
+                    code_chunks.append(chunk)
+                code = b''.join(code_chunks).decode('utf-8', errors='replace')
+            except Exception as e:
+                return {"error": f"Failed to fetch code from code_url: {str(e)}"}, '/v1/code/execute/python', 400
+        else:
+            code = data['code']
         timeout = data.get('timeout', 30)
-        
+        env = {str(k): str(v) for k, v in data.get('env', {}).items()}
         # Indent user code
         indented_code = textwrap.indent(code, '    ')
         
@@ -99,6 +127,7 @@ print(json.dumps(result))
                     ['python3', temp_file.name],
                     capture_output=True,
                     text=True,
+                    env=env,
                     timeout=timeout
                 )
                 


### PR DESCRIPTION
## Added support for `code_url` in code execution endpoint

### Summary
- Added support for `code_url` as an alternative to `code` in the payload. Only one can be provided at a time.
- Enforced a 1MB size limit for code fetched via `code_url`, with streaming and early abort if the file is too large.
- Updated validation to require either `code` or `code_url`, but not both.
- The `env` input is supported for setting environment variables during code execution.

### Example payloads

```json
{
  "code": "import os\nprint(os.environ.get('MY_TEST_VAR'))\nreturn os.environ.get('MY_TEST_VAR')",
  "env": {
    "MY_TEST_VAR": "hello_env"
  }
}
```
```json
{
  "code_url": "https://pastebin.com/raw/6i1uUc0f",
  "env": {
    "MY_TEST_VAR": "hello_env"
  }
}
```