### PR TITLE
added exclude_time_ranges to /v1/video/caption

### DIFF
--- a/docs/video/caption_video.md
+++ b/docs/video/caption_video.md
@@ -30,6 +30,10 @@ The request body must be a JSON object with the following properties:
 - `webhook_url` (string, optional): A URL to receive a webhook notification when the captioning process is complete.
 - `id` (string, optional): An identifier for the request.
 - `language` (string, optional): The language code for the captions (e.g., "en", "fr"). Defaults to "auto".
+- `exclude_time_ranges` (array, optional): List of time ranges to skip when adding captions. Each item must be an object with:
+  - `start`: (number or string, required) The non-negative start time of the excluded range.
+  - `end`: (number or string, required) The non-negative end time, which must be strictly greater than `start`.
+  If `start` or `end` is negative, or if `end` is not greater than `start`, the request will return an error.
 
 #### Settings Schema
 
@@ -157,6 +161,25 @@ This minimal request will automatically transcribe the video and add white capti
         "font_family": "Arial",
         "font_size": 24
     }
+}
+```
+
+#### Example 5: Excluding Time Ranges from Captioning
+```json
+{
+    "video_url": "https://example.com/video.mp4",
+    "settings": {
+        "style": "classic",
+        "line_color": "#FFFFFF",
+        "outline_color": "#000000",
+        "position": "bottom_center",
+        "font_family": "Arial",
+        "font_size": 24
+    },
+    "exclude_time_ranges": [
+        { "start": 0, "end": 5 },
+        { "start": "10.5", "end": "15.0" }
+    ]
 }
 ```
 
@@ -314,6 +337,7 @@ Additionally, the main application context (`app.py`) includes error handling fo
 - The `webhook_url` parameter is optional and can be used to receive a notification when the captioning process is complete.
 - The `id` parameter is optional and can be used to identify the request in webhook responses.
 - The `language` parameter is optional and can be used to specify the language of the captions for transcription. If not provided, the language will be automatically detected.
+- The `exclude_time_ranges` parameter can be used to specify time ranges to be excluded from captioning. Each range must have a non-negative `start` and `end` time, and `end` must be greater than `start`. Negative values are not allowed and will result in an error.
 
 ## 7. Common Issues
 

--- a/docs/video/caption_video.md
+++ b/docs/video/caption_video.md
@@ -31,9 +31,9 @@ The request body must be a JSON object with the following properties:
 - `id` (string, optional): An identifier for the request.
 - `language` (string, optional): The language code for the captions (e.g., "en", "fr"). Defaults to "auto".
 - `exclude_time_ranges` (array, optional): List of time ranges to skip when adding captions. Each item must be an object with:
-  - `start`: (number or string, required) The non-negative start time of the excluded range.
-  - `end`: (number or string, required) The non-negative end time, which must be strictly greater than `start`.
-  If `start` or `end` is negative, or if `end` is not greater than `start`, the request will return an error.
+  - `start`: (string, required) The start time of the excluded range, as a string timecode in `hh:mm:ss.ms` format (e.g., `00:01:23.456`).
+  - `end`: (string, required) The end time, as a string timecode in `hh:mm:ss.ms` format, which must be strictly greater than `start`.
+  If either value is not a valid timecode string, or if `end` is not greater than `start`, the request will return an error.
 
 #### Settings Schema
 
@@ -177,8 +177,8 @@ This minimal request will automatically transcribe the video and add white capti
         "font_size": 24
     },
     "exclude_time_ranges": [
-        { "start": 0, "end": 5 },
-        { "start": "10.5", "end": "15.0" }
+        { "start": "00:00:10.000", "end": "00:00:20.000" },
+        { "start": "00:00:30.000", "end": "00:00:40.000" }
     ]
 }
 ```
@@ -337,7 +337,7 @@ Additionally, the main application context (`app.py`) includes error handling fo
 - The `webhook_url` parameter is optional and can be used to receive a notification when the captioning process is complete.
 - The `id` parameter is optional and can be used to identify the request in webhook responses.
 - The `language` parameter is optional and can be used to specify the language of the captions for transcription. If not provided, the language will be automatically detected.
-- The `exclude_time_ranges` parameter can be used to specify time ranges to be excluded from captioning. Each range must have a non-negative `start` and `end` time, and `end` must be greater than `start`. Negative values are not allowed and will result in an error.
+- The `exclude_time_ranges` parameter can be used to specify time ranges to be excluded from captioning.
 
 ## 7. Common Issues
 

--- a/routes/v1/video/caption_video.py
+++ b/routes/v1/video/caption_video.py
@@ -85,6 +85,17 @@ logger = logging.getLogger(__name__)
                 "required": ["find", "replace"]
             }
         },
+        "exclude_time_ranges": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "start": { "type": "number", "minimum": 0 },
+                    "end": { "type": "number", "minimum": 0 }
+                },
+                "required": ["start", "end"]
+            }
+        },
         "webhook_url": {"type": "string", "format": "uri"},
         "id": {"type": "string"},
         "language": {"type": "string"}
@@ -98,6 +109,7 @@ def caption_video_v1(job_id, data):
     captions = data.get('captions')
     settings = data.get('settings', {})
     replace = data.get('replace', [])
+    exclude_time_ranges = data.get('exclude_time_ranges', [])
     webhook_url = data.get('webhook_url')
     id = data.get('id')
     language = data.get('language', 'auto')
@@ -105,6 +117,7 @@ def caption_video_v1(job_id, data):
     logger.info(f"Job {job_id}: Received v1 captioning request for {video_url}")
     logger.info(f"Job {job_id}: Settings received: {settings}")
     logger.info(f"Job {job_id}: Replace rules received: {replace}")
+    logger.info(f"Job {job_id}: Exclude time ranges received: {exclude_time_ranges}")
 
     try:
         # Do NOT combine position and alignment. Keep them separate.
@@ -112,7 +125,7 @@ def caption_video_v1(job_id, data):
         # This ensures position and alignment remain independent keys.
         
         # Process video with the enhanced v1 service
-        output = process_captioning_v1(video_url, captions, settings, replace, job_id, language)
+        output = process_captioning_v1(video_url, captions, settings, replace, exclude_time_ranges, job_id, language)
         
         if isinstance(output, dict) and 'error' in output:
             # Check if this is a font-related error by checking for 'available_fonts' key

--- a/routes/v1/video/caption_video.py
+++ b/routes/v1/video/caption_video.py
@@ -90,10 +90,11 @@ logger = logging.getLogger(__name__)
             "items": {
                 "type": "object",
                 "properties": {
-                    "start": { "type": "number", "minimum": 0 },
-                    "end": { "type": "number", "minimum": 0 }
+                    "start": { "anyOf": [ { "type": "number", "minimum": 0 }, { "type": "string" } ] },
+                    "end": { "anyOf": [ { "type": "number", "minimum": 0 }, { "type": "string" } ] }
                 },
-                "required": ["start", "end"]
+                "required": ["start", "end"],
+                "additionalProperties": False
             }
         },
         "webhook_url": {"type": "string", "format": "uri"},

--- a/routes/v1/video/caption_video.py
+++ b/routes/v1/video/caption_video.py
@@ -90,8 +90,8 @@ logger = logging.getLogger(__name__)
             "items": {
                 "type": "object",
                 "properties": {
-                    "start": { "anyOf": [ { "type": "number", "minimum": 0 }, { "type": "string" } ] },
-                    "end": { "anyOf": [ { "type": "number", "minimum": 0 }, { "type": "string" } ] }
+                    "start": { "type": "string" },
+                    "end": { "type": "string" }
                 },
                 "required": ["start", "end"],
                 "additionalProperties": False


### PR DESCRIPTION
## Description
- Added exclude_time_ranges to the /v1/video/caption endpoint.
- Lets users skip captioning during specified time ranges.

## Example Payload
```json
{
    "video_url": "https://storage.googleapis.com/sgplabs-general-storage/Vertical%20Video.mp4",
    "replace": [
        {
            "find": "you",
            "replace": "#$%#$#%$#%"
        }
    ],
    "settings": {
        "line_color": "#FFFFFF",
        "word_color": "#FFFF00",
        "all_caps": false,
        "max_words_per_line": 3,
        "font_size": 60,
        "bold": false,
        "italic": false,
        "underline": false,
        "strikeout": false,
        "outline_width": 3,
        "shadow_offset": 4,
        "style": "highlight",
        "font_family": "The Bold Font",
        "position": "bottom_center"
    },
    "exclude_time_ranges": [
        { "start": 0, "end": 3 },
        { "start": 7, "end": 10 }
    ],
    "id": "gdrive-five"
}