### PR TITLE
💰📉 Long-Running Tasks with Cloud Run Job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -193,6 +193,7 @@ gunicorn --bind 0.0.0.0:8080 \
     --timeout ${GUNICORN_TIMEOUT:-300} \
     --worker-class sync \
     --keep-alive 80 \
+    --config gunicorn.conf.py \
     app:app' > /app/run_gunicorn.sh && \
     chmod +x /app/run_gunicorn.sh
 

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2025 Stephen G. Pope
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+###########################################################################
+
+# Author: Harrison Fisher (https://github.com/HarrisonFisher)
+# Date: May 2025
+# Description: This script configures the server to automatically trigger a job request 
+#              at startup, monitor its status if a webhook URL is provided, 
+#              and shut down the server once the job completes or if an error occurs.
+
+import os
+import json
+import requests
+import signal
+import sys
+import time
+import threading
+from flask import request
+
+def wait_for_job_to_complete(api_url, api_key, job_id, poll_interval=5):
+    headers = {'x-api-key': api_key}
+    consecutive_failures = 0
+    max_failures = 2
+
+    while consecutive_failures <= max_failures:
+        try:
+            response = requests.post(
+                f"{api_url}/v1/toolkit/job/status",
+                json={"job_id": job_id},
+                headers=headers
+            )
+
+            if response.status_code != 200:
+                print(f"Failed to get job status: {response.status_code}")
+                consecutive_failures += 1
+            else:
+                job_status = response.json()
+                status = job_status.get("response", {}).get("job_status")
+
+                if status and status != "running":
+                    print(f"✅ Job {job_id} has completed with status: {status}")
+                    return True
+
+                consecutive_failures = 0  # Reset on success
+
+        except Exception as e:
+            print("Error checking job status:", e)
+            consecutive_failures += 1
+
+        if consecutive_failures > max_failures:
+            print("❌ Too many consecutive failures. Giving up.")
+            return False
+
+        time.sleep(poll_interval)
+
+    print("🔁 Exited polling loop without determining job status.")
+    return False
+
+
+def cloud_run_job_task():
+    path = os.environ.get("CLOUD_RUN_JOB_PATH")
+    payload = os.environ.get("CLOUD_RUN_JOB_PAYLOAD")
+    api_key = os.environ.get("API_KEY")
+
+    if path and payload and api_key:
+        try:
+            print("📤 Sending auto request...")
+            time.sleep(1)
+            response = requests.post(f"http://localhost:8080{path}", json=json.loads(payload), headers={
+                "x-api-key": api_key,
+                "Content-Type": "application/json"
+            })
+
+            if response.status_code == 200 or response.status_code == 202:
+                print("✅ Request sent successfully. Response:")
+                response_json = response.json()
+                print(json.dumps(response_json, indent=4))
+
+                job_id = response_json.get("job_id")
+            
+                if job_id:
+                    parsed_payload = json.loads(payload)
+                    if "webhook_url" in parsed_payload:
+                        print("🔔 Webhook URL detected in payload. Monitoring job to trigger webhook.")
+                        wait_for_job_to_complete(
+                            "http://localhost:8080",
+                            api_key,
+                            job_id,
+                        )
+                        time.sleep(1) # Wait for webhook to trigger (could be optimized???)
+                    else:
+                        print("📭 No webhook URL found. Skipping job monitoring.")
+                else:
+                    print("⚠️ No job_id found in response. Cannot monitor job status.")
+
+            else:
+                print(f"❌ Request failed with status code {response.status_code}. Response:")
+                print(json.dumps(response.json(), indent=4))
+            
+
+        except Exception as e:
+            print("❌ Error sending auto request:", e)
+            os._exit(1)
+        finally:
+            print("🛑 Shutting down server...")
+            os._exit(0)
+    else:
+        print("⚠️ Environment variables PATH, PAYLOAD, and API_KEY must be set.")
+        os._exit(1)    
+
+
+def when_ready(server):
+    """Hook called when the server is ready."""
+    if os.environ.get("CLOUD_RUN_JOB", "") != "":
+        thread = threading.Thread(target=cloud_run_job_task)
+        thread.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,9 @@ google-auth
 google-auth-oauthlib
 google-auth-httplib2
 google-api-python-client
+google-api-core
 google-cloud-storage
+google-cloud-run
 psutil
 boto3
 Pillow

--- a/routes/v1/toolkit/job_status.py
+++ b/routes/v1/toolkit/job_status.py
@@ -44,7 +44,7 @@ def get_job_status(job_id, data):
     get_job_id = data.get('job_id')
 
     logger.info(f"Retrieving status for job {get_job_id}")
-    
+    endpoint = "/v1/toolkit/job/status"
     try:
         # Construct the path to the job status file
         job_file_path = os.path.join(LOCAL_STORAGE_PATH, 'jobs', f"{get_job_id}.json")
@@ -58,7 +58,7 @@ def get_job_status(job_id, data):
             job_status = json.load(file)
         
         # Return the job status file content directly
-        return job_status, "/v1/toolkit/job/status", 200
+        return job_status, endpoint, 200
         
     except Exception as e:
         logger.error(f"Error retrieving status for job {get_job_id}: {str(e)}")

--- a/services/gcp_toolkit.py
+++ b/services/gcp_toolkit.py
@@ -21,6 +21,8 @@ import json
 import logging
 from google.oauth2 import service_account
 from google.cloud import storage
+from google.cloud.run_v2 import JobsClient, RunJobRequest
+from google.api_core.exceptions import GoogleAPIError
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -69,3 +71,41 @@ def upload_to_gcs(file_path, bucket_name=GCP_BUCKET_NAME):
     except Exception as e:
         logger.error(f"Error uploading file to GCS: {e}")
         raise
+
+
+def trigger_cloud_run_job(job_name, location="us-central1", overrides=None):
+    # Retrieve service account credentials
+    json_str = os.environ.get("GCP_SA_CREDENTIALS")
+    if not json_str:
+        raise ValueError("GCP_SA_CREDENTIALS environment variable not set.")
+    
+    credentials_info = json.loads(json_str)
+    credentials = service_account.Credentials.from_service_account_info(credentials_info)
+
+    # Initialize the JobsClient with the provided credentials
+    client = JobsClient(credentials=credentials)
+
+    # Construct the job path using project ID and location
+    project_id = credentials_info.get("project_id")
+    job_path = f"projects/{project_id}/locations/{location}/jobs/{job_name}"
+
+    # Create the RunJobRequest with the specified overrides
+    request = RunJobRequest(
+        name=job_path,
+        overrides=overrides  # Passing the overrides dictionary directly
+    )
+
+    try:
+        # Trigger the job (non-blocking)
+        operation = client.run_job(request=request)
+
+        return {
+            "operation_name": operation.operation.name,  # Return operation name to track job status
+            "job_submitted": True
+        }
+    except GoogleAPIError as e:
+        # Handle any errors (e.g., authentication, bad request)
+        return {
+            "job_submitted": False,
+            "error": str(e)
+        }


### PR DESCRIPTION
### Description:

This PR introduces a cost-effective solution for **long-running tasks** (over 5 minutes) on **Google Cloud Run**, eliminating the need for a constantly running server (like those on DigitalOcean). By leveraging **Cloud Run Jobs**, tasks can be processed asynchronously, reducing operational costs while maintaining **scalability** and **reliability**.

#### Key Features:

* 🕒 **Asynchronous Processing**: Supports long-running tasks without the need for an always-on server.
* 💸 **Cost Savings**: Cloud Run charges only for the time the job runs, offering significant savings over traditional servers.

---

### ⚙️ Configuration Changes:

#### 1. **Setting Up the Cloud Run Job**:

To create the job that will handle your long-running tasks:

* Go to the **Google Cloud Console** and navigate to **Cloud Run**.
* Click **Create Job** and configure the necessary settings (runtime, environment variables, etc.).
* Make sure to set any required **API key** and **cloud storage environment variables**.
* Set the **preferred task timeout** (maximum allowed: **10,080 minutes**).
* 💡 **Use sufficient memory**—do **not** rely on the default 512MiB.

#### 2. **Cloud Run Service Configuration**:

Update your Cloud Run service with the following environment variables to enable job triggering:

* **`GCP_SA_CREDENTIALS`**: A service account JSON with the `Cloud Run Jobs Executor With Overrides` role.
* **`CLOUD_RUN_JOB_NAME`**: The name of the job to be triggered.
* **`CLOUD_RUN_JOB_LOCATION`** *(optional)*: Region for the job (default: `us-central1`).

Example `.env`:

```env
GCP_SA_CREDENTIALS={"your":"service_account_json"}
CLOUD_RUN_JOB_NAME=my-cloud-run-job
CLOUD_RUN_JOB_LOCATION=us-central1
```

---

### 🚀 Usage:

* When `CLOUD_RUN_JOB_NAME` is set and a `webhook_url` is provided, the Flask service will trigger the Cloud Run job asynchronously using the supplied payload.

