### PR TITLE
fix: replace libsvtav1-dev with libsvtav1enc-dev for Debian Trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libaom-dev \
     libdav1d-dev \
     librav1e-dev \
-    libsvtav1-dev \
+    libsvtav1enc-dev \
     libzimg-dev \
     libwebp-dev \
     git \


### PR DESCRIPTION
Debian Trixie (base image python:3.9-slim) no longer provides libsvtav1-dev.
The package was renamed to libsvtav1enc-dev.
This PR updates the Dockerfile accordingly to allow FFmpeg build to succeed.
