### PR TITLE
Fix the font_family setting and response encoding.

### DIFF
--- a/services/ass_toolkit.py
+++ b/services/ass_toolkit.py
@@ -169,6 +169,7 @@ def download_captions(captions_url):
         logger.info(f"Downloading captions from URL: {captions_url}")
         response = requests.get(captions_url)
         response.raise_for_status()
+        response.encoding = 'utf-8' 
         logger.info("Captions downloaded successfully.")
         return response.text
     except Exception as e:


### PR DESCRIPTION
When attempting to add Chinese subtitles to videos using the /v1/video/caption endpoint, I've discovered that specifying "font_family": "HarmonyOS Sans SC" within the JSON request results in the subtitles failing to render. 
Two issues are present: 
1. parameter transmission,  
2. the download of captions is failing to utilize the correct encoding, leading to libass being unable to parse them and consequently falling back to Arial.ttf. 
3. This patch rectifies these issues.