### PR TITLE
Add S3_PUBLIC_URL environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ API_KEY=your_api_key_here
 #S3_REGION=your-region
 #S3_BUCKET_NAME=your-bucket-name
 
+# optional
+# Purpose: S3_PUBLIC_URL custom domain for returned file URLs (e.g., CDN or Cloudflare R2 custom domain)
+# When set, file URLs will use this domain without the bucket name in the path
+#S3_PUBLIC_URL=https://subdomain.domain.com
+
 
 # Google Cloud Storage Env Variables
 #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,21 +26,16 @@ No-Code Architects Toolkit API is a Flask-based media processing API that handle
   - Validates required environment variables per storage provider
   - Configures API_KEY, storage paths, and cloud credentials
 
-- **[gunicorn.conf.py](gunicorn.conf.py)** - Gunicorn server configuration
-  - Defines `when_ready` hook that auto-executes jobs in Cloud Run Job context
-  - Reads GCP_JOB_PATH and GCP_JOB_PAYLOAD env vars to make internal request
-  - Sends error webhooks if job fails, then shuts down container
-
 ### Request Flow
 
-1. Request hits route in `routes/v1/{category}/{action}.py` or `routes/v1/{category}/{subcategory}/{action}.py`
+1. Request hits route in `routes/v1/{category}/{action}.py`
 2. `@authenticate` decorator validates X-API-Key header
-3. `@validate_payload()` validates JSON against schema (strips internal `_cloud_job_id` and `disable_cloud_job` before validation)
+3. `@validate_payload()` validates JSON against schema
 4. `@queue_task_wrapper()` determines processing path:
    - **No webhook_url**: Execute synchronously, return immediately
    - **With webhook_url**: Queue task, return 202, send webhook when done
-   - **GCP_JOB_NAME set + webhook_url + not disabled**: Trigger Cloud Run Job, return 202
-   - **CLOUD_RUN_JOB env set**: Execute synchronously in job context (auto-triggered by gunicorn `when_ready` hook)
+   - **GCP_JOB_NAME set + webhook_url**: Trigger Cloud Run Job, return 202
+   - **CLOUD_RUN_JOB env set**: Execute synchronously in job context
 
 5. Route calls service function in `services/v1/{category}/{action}.py`
 6. Service processes media, uploads to cloud storage, returns result
@@ -56,9 +51,7 @@ No-Code Architects Toolkit API is a Flask-based media processing API that handle
 **GCP Cloud Run Jobs** (Optional)
 - Set GCP_JOB_NAME and GCP_JOB_LOCATION to enable
 - Requires webhook_url in request payload
-- Can be disabled via DISABLE_CLOUD_JOB env var or `disable_cloud_job: true` in payload
-- Triggers Cloud Run Job with endpoint and payload as env vars (including `_cloud_job_id` to preserve job tracking)
-- Job auto-executes via gunicorn `when_ready` hook, then shuts down
+- Triggers Cloud Run Job with endpoint and payload as env vars
 - Job executes task independently and sends webhook
 
 **Synchronous** (No Queue)
@@ -68,13 +61,6 @@ No-Code Architects Toolkit API is a Flask-based media processing API that handle
 ### Dynamic Route Registration
 
 Routes are auto-discovered from `routes/` directory. No manual registration needed in [app.py](app.py).
-
-**File Structure:**
-- Simple routes: `routes/v1/{category}/{action}.py`
-- Nested routes: `routes/v1/{category}/{subcategory}/{action}.py`
-- Examples:
-  - `routes/v1/media/convert/media_convert.py` → `/v1/media/convert`
-  - `routes/v1/video/caption_video.py` → `/v1/video/caption`
 
 **Blueprint Convention:**
 ```python
@@ -92,7 +78,7 @@ def action_handler(job_id, data):
     """
     Args:
         job_id (str): Unique job identifier
-        data (dict): Request JSON payload (internal fields _cloud_job_id and disable_cloud_job already stripped)
+        data (dict): Request JSON payload
 
     Returns:
         Tuple[dict, str, int]: (response_data, endpoint_path, status_code)
@@ -183,13 +169,7 @@ S3-Compatible:
 - `GUNICORN_TIMEOUT` - Worker timeout seconds (default: 30)
 - `GCP_JOB_NAME` - Cloud Run Job name for offloading
 - `GCP_JOB_LOCATION` - Cloud Run Job region (default: us-central1)
-- `DISABLE_CLOUD_JOB` - Set to "true" or "1" to disable Cloud Run Job triggering globally
 - `S3_PUBLIC_URL` - Custom domain for S3 file URLs (e.g., "subdomain.domain.com"). When set, URLs exclude bucket name and use this domain instead of S3_ENDPOINT_URL
-
-**Payload-Level Parameters:**
-- `webhook_url` - URL to POST results when job completes (enables async processing)
-- `disable_cloud_job` - Set to `true` to disable Cloud Run Job for this request (overrides env var if set to `false`)
-- `_cloud_job_id` - Internal parameter used to preserve job IDs across Cloud Run Job invocations (do not use manually)
 
 ## Key Patterns
 
@@ -257,10 +237,7 @@ See [docs/adding_routes.md](docs/adding_routes.md) for full guide.
 ## Contributing
 
 - Submit PRs to `build` branch (not main)
-- Use auto-versioning: builds auto-increment via GitHub Actions on push to `build`
-  - Workflow updates `version.py` and `build_number.txt`
-  - Automatically pushes to `testing` branch
-  - Use `[skip ci]` in commit messages to prevent build number increment
+- Use auto-versioning: builds auto-increment via GitHub Actions
 - Update README.md when adding new endpoints
 - Follow GPL-2.0 license (see [LICENSE](LICENSE))
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,16 +26,21 @@ No-Code Architects Toolkit API is a Flask-based media processing API that handle
   - Validates required environment variables per storage provider
   - Configures API_KEY, storage paths, and cloud credentials
 
+- **[gunicorn.conf.py](gunicorn.conf.py)** - Gunicorn server configuration
+  - Defines `when_ready` hook that auto-executes jobs in Cloud Run Job context
+  - Reads GCP_JOB_PATH and GCP_JOB_PAYLOAD env vars to make internal request
+  - Sends error webhooks if job fails, then shuts down container
+
 ### Request Flow
 
-1. Request hits route in `routes/v1/{category}/{action}.py`
+1. Request hits route in `routes/v1/{category}/{action}.py` or `routes/v1/{category}/{subcategory}/{action}.py`
 2. `@authenticate` decorator validates X-API-Key header
-3. `@validate_payload()` validates JSON against schema
+3. `@validate_payload()` validates JSON against schema (strips internal `_cloud_job_id` and `disable_cloud_job` before validation)
 4. `@queue_task_wrapper()` determines processing path:
    - **No webhook_url**: Execute synchronously, return immediately
    - **With webhook_url**: Queue task, return 202, send webhook when done
-   - **GCP_JOB_NAME set + webhook_url**: Trigger Cloud Run Job, return 202
-   - **CLOUD_RUN_JOB env set**: Execute synchronously in job context
+   - **GCP_JOB_NAME set + webhook_url + not disabled**: Trigger Cloud Run Job, return 202
+   - **CLOUD_RUN_JOB env set**: Execute synchronously in job context (auto-triggered by gunicorn `when_ready` hook)
 
 5. Route calls service function in `services/v1/{category}/{action}.py`
 6. Service processes media, uploads to cloud storage, returns result
@@ -51,7 +56,9 @@ No-Code Architects Toolkit API is a Flask-based media processing API that handle
 **GCP Cloud Run Jobs** (Optional)
 - Set GCP_JOB_NAME and GCP_JOB_LOCATION to enable
 - Requires webhook_url in request payload
-- Triggers Cloud Run Job with endpoint and payload as env vars
+- Can be disabled via DISABLE_CLOUD_JOB env var or `disable_cloud_job: true` in payload
+- Triggers Cloud Run Job with endpoint and payload as env vars (including `_cloud_job_id` to preserve job tracking)
+- Job auto-executes via gunicorn `when_ready` hook, then shuts down
 - Job executes task independently and sends webhook
 
 **Synchronous** (No Queue)
@@ -61,6 +68,13 @@ No-Code Architects Toolkit API is a Flask-based media processing API that handle
 ### Dynamic Route Registration
 
 Routes are auto-discovered from `routes/` directory. No manual registration needed in [app.py](app.py).
+
+**File Structure:**
+- Simple routes: `routes/v1/{category}/{action}.py`
+- Nested routes: `routes/v1/{category}/{subcategory}/{action}.py`
+- Examples:
+  - `routes/v1/media/convert/media_convert.py` → `/v1/media/convert`
+  - `routes/v1/video/caption_video.py` → `/v1/video/caption`
 
 **Blueprint Convention:**
 ```python
@@ -78,7 +92,7 @@ def action_handler(job_id, data):
     """
     Args:
         job_id (str): Unique job identifier
-        data (dict): Request JSON payload
+        data (dict): Request JSON payload (internal fields _cloud_job_id and disable_cloud_job already stripped)
 
     Returns:
         Tuple[dict, str, int]: (response_data, endpoint_path, status_code)
@@ -169,6 +183,13 @@ S3-Compatible:
 - `GUNICORN_TIMEOUT` - Worker timeout seconds (default: 30)
 - `GCP_JOB_NAME` - Cloud Run Job name for offloading
 - `GCP_JOB_LOCATION` - Cloud Run Job region (default: us-central1)
+- `DISABLE_CLOUD_JOB` - Set to "true" or "1" to disable Cloud Run Job triggering globally
+- `S3_PUBLIC_URL` - Custom domain for S3 file URLs (e.g., "subdomain.domain.com"). When set, URLs exclude bucket name and use this domain instead of S3_ENDPOINT_URL
+
+**Payload-Level Parameters:**
+- `webhook_url` - URL to POST results when job completes (enables async processing)
+- `disable_cloud_job` - Set to `true` to disable Cloud Run Job for this request (overrides env var if set to `false`)
+- `_cloud_job_id` - Internal parameter used to preserve job IDs across Cloud Run Job invocations (do not use manually)
 
 ## Key Patterns
 
@@ -236,7 +257,10 @@ See [docs/adding_routes.md](docs/adding_routes.md) for full guide.
 ## Contributing
 
 - Submit PRs to `build` branch (not main)
-- Use auto-versioning: builds auto-increment via GitHub Actions
+- Use auto-versioning: builds auto-increment via GitHub Actions on push to `build`
+  - Workflow updates `version.py` and `build_number.txt`
+  - Automatically pushes to `testing` branch
+  - Use `[skip ci]` in commit messages to prevent build number increment
 - Update README.md when adding new endpoints
 - Follow GPL-2.0 license (see [LICENSE](LICENSE))
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,16 @@ Each endpoint is supported by robust payload validation and detailed API documen
 - **Purpose**: The region for the S3-compatible storage service.
 - **Requirement**: Mandatory if using S3-compatible storage, "None" is acceptible for some s3 providers.
 
+#### `S3_PUBLIC_URL`
+- **Purpose**: Custom domain to use as the base URL for all returned file URLs (e.g., CDN domain).
+- **Requirement**: Optional. When set, file URLs will use this domain instead of `S3_ENDPOINT_URL`, and the bucket name will be excluded from the URL path.
+- **Example**: Set to `subdomain.domain.com` to return URLs like `https://subdomain.domain.com/file.mp3` instead of `https://nyc3.digitaloceanspaces.com/bucket-name/file.mp3`
+- **Note**: The value can include or exclude the `https://` protocol prefix. If omitted, `https://` will be automatically prepended.
+- **Common Use Cases**:
+  1. **Cloudflare R2 Public Access**: Cloudflare R2 requires custom domains (without bucket names in the URL path) to serve files publicly without authentication. Set `S3_PUBLIC_URL` to your R2 custom domain to enable public file access.
+  2. **CDN Integration**: Use CloudFlare, AWS CloudFront, Fastly, or other CDNs in front of your S3 storage for improved performance, caching, and reduced bandwidth costs. Set `S3_PUBLIC_URL` to your CDN domain.
+  3. **Custom Domain Branding**: Use your own branded domain (e.g., `files.yourcompany.com`) instead of exposing the underlying cloud provider's domain in file URLs, providing a more professional appearance and easier domain migration.
+
 ---
 
 ### Google Cloud Storage (GCP) Environment Variables

--- a/config.py
+++ b/config.py
@@ -31,6 +31,9 @@ LOCAL_STORAGE_PATH = os.environ.get('LOCAL_STORAGE_PATH', '/tmp')
 GCP_SA_CREDENTIALS = os.environ.get('GCP_SA_CREDENTIALS', '')
 GCP_BUCKET_NAME = os.environ.get('GCP_BUCKET_NAME', '')
 
+# S3 public URL override (optional) - when set, uses this as base URL instead of S3_ENDPOINT_URL
+S3_PUBLIC_URL = os.environ.get('S3_PUBLIC_URL', '')
+
 def validate_env_vars(provider):
 
     """ Validate the necessary environment variables for the selected storage provider """

--- a/docker-compose.md
+++ b/docker-compose.md
@@ -140,6 +140,11 @@ API_KEY=your_api_key_here
 #S3_REGION=your-region
 #S3_BUCKET_NAME=your-bucket-name
 
+# optional
+# Purpose: S3_PUBLIC_URL custom domain for returned file URLs (e.g., CDN or Cloudflare R2 custom domain)
+# When set, file URLs will use this domain without the bucket name in the path
+#S3_PUBLIC_URL=https://subdomain.domain.com
+
 
 # Google Cloud Storage Env Variables
 #

--- a/docs/cloud-installation/do.md
+++ b/docs/cloud-installation/do.md
@@ -59,12 +59,22 @@ You'll need to create a Space (Digital Ocean's object storage) for the toolkit t
 
 Add the following environment variables exactly as shown (be careful with underscores vs. dashes and avoid any leading/trailing spaces):
 
+### Required Variables
+
 1. `API_KEY`: Your API key (e.g., `test123` for testing - change for production)
 2. `S3_ENDPOINT_URL`: The URL of your Space (copied from Step 3)
 3. `S3_ACCESS_KEY`: The access key from Step 3
 4. `S3_SECRET_KEY`: The secret key from Step 3
 5. `S3_BUCKET_NAME`: The name of your Space bucket (e.g., `nca-toolkit-bucket`)
 6. `S3_REGION`: The region code of your Space (e.g., `NYC3` for New York)
+
+### Optional Variables
+
+7. `S3_PUBLIC_URL`: Custom domain for file URLs (e.g., `cdn.yourdomain.com`)
+   - Use this if you have a CDN or custom domain in front of your Space
+   - When set, returned file URLs will use this domain instead of the Digital Ocean Spaces URL
+   - The bucket name will be excluded from the URL path
+   - Example: If set to `files.example.com`, URLs will be `https://files.example.com/file.mp3` instead of `https://nyc3.digitaloceanspaces.com/bucket-name/file.mp3`
 
 ## Step 7: Finalize and Deploy
 

--- a/services/s3_toolkit.py
+++ b/services/s3_toolkit.py
@@ -42,7 +42,19 @@ def upload_to_s3(file_path, s3_url, access_key, secret_key, bucket_name, region)
 
         # URL encode the filename for the URL
         encoded_filename = quote(os.path.basename(file_path))
-        file_url = f"{s3_url}/{bucket_name}/{encoded_filename}"
+
+        # Check if S3_PUBLIC_URL is set for custom domain
+        public_url = os.getenv('S3_PUBLIC_URL', '').strip()
+        if public_url:
+            # Ensure https:// prefix if not present
+            if not public_url.startswith('http'):
+                public_url = f"https://{public_url}"
+            # Use public URL without bucket name
+            file_url = f"{public_url}/{encoded_filename}"
+        else:
+            # Use existing logic with bucket name
+            file_url = f"{s3_url}/{bucket_name}/{encoded_filename}"
+
         return file_url
     except Exception as e:
         logger.error(f"Error uploading file to S3: {e}")

--- a/services/v1/s3/upload.py
+++ b/services/v1/s3/upload.py
@@ -153,7 +153,18 @@ def stream_upload_to_s3(file_url, custom_filename=None, make_public=False, downl
         if make_public:
             # URL encode the filename for the URL only
             encoded_filename = quote(filename)
-            file_url = f"{endpoint_url}/{bucket_name}/{encoded_filename}"
+
+            # Check if S3_PUBLIC_URL is set for custom domain
+            public_url = os.getenv('S3_PUBLIC_URL', '').strip()
+            if public_url:
+                # Ensure https:// prefix if not present
+                if not public_url.startswith('http'):
+                    public_url = f"https://{public_url}"
+                # Use public URL without bucket name
+                file_url = f"{public_url}/{encoded_filename}"
+            else:
+                # Use existing logic with bucket name
+                file_url = f"{endpoint_url}/{bucket_name}/{encoded_filename}"
         else:
             # Generate a pre-signed URL for private files
             file_url = s3_client.generate_presigned_url(


### PR DESCRIPTION
# Motivation
See discussion at https://github.com/stephengpope/no-code-architects-toolkit/issues/222

## Summary
This PR introduces a new optional environment variable `S3_PUBLIC_URL` that allows users to specify a custom public domain for S3 file URLs, enabling CDN integration, custom domain branding, and proper Cloudflare R2 public access.

## Changes
•  New Environment Variable: `S3_PUBLIC_URL` - optional configuration for customizing the base URL of returned file URLs


## Updated Files:
◦  .env.example - added configuration example
◦  README.md - documented the new variable with use cases
◦  docker-compose.md - added setup instructions
◦  docs/cloud-installation/do.md - included Digital Ocean-specific guidance
◦  config.py - added configuration loading
◦  services/s3_toolkit.py - implemented URL transformation logic
◦  services/v1/s3/upload.py - applied custom URL for public file uploads
◦  CLAUDE.md - updated documentation with implementation details

## Key Features
•  CDN Integration: Seamlessly use CloudFlare, AWS CloudFront, Fastly, or other CDNs for improved performance and reduced bandwidth costs
•  Cloudflare R2 Support: Enables public file access on R2, which requires custom domains without bucket names in URL paths
•  Custom Domain Branding: Use branded domains (e.g., files.yourcompany.com) instead of exposing cloud provider domains
•  Flexible Protocol Handling: Automatically prepends https:// if not specified
•  Backward Compatible: Existing deployments continue working without any changes

## Use Cases
1. Cloudflare R2 public access (requires custom domains)
2. CDN integration for performance and cost optimization
3. Custom domain branding for professional appearance
4. Reverse proxy and geo-routing configurations

## Testing
•  Verified backward compatibility (works without the variable set)
•  Tested with custom domain URLs (with and without https:// prefix)
•  Confirmed bucket name exclusion from public URLs when S3_PUBLIC_URL is set

Image available on Docker Hub as `gmarcus/no-code-architects-toolkit:latest`