### PR TITLE
Update python to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 # Install system dependencies, build tools, and libraries
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Updated python to 3.11

Error: 400 Bad Request message
/v1/code/execute/python

FutureWarning: You are using a Python version (3.10.19) which Google will stop supporting in new releases of google.api_core once it reaches its end of life (2026-10-04). Please upgrade to the latest Python version, or at least Python 3.11, to continue receiving updates for google.api_core past that date.\n warnings.warn(message, FutureWarning)
