### PR TITLE
fix: UnboundLocalError in transcribe when cloud + include_text=false

### DIFF
--- a/services/v1/media/media_transcribe.py
+++ b/services/v1/media/media_transcribe.py
@@ -134,7 +134,7 @@ def process_transcribe_media(media_url, task, include_text, include_srt, include
                 with open(text_filename, 'w') as f:
                     f.write(text)
             else:
-                text_file = None
+                text_filename = None
             
             if include_srt is True:
                 srt_filename = os.path.join(LOCAL_STORAGE_PATH, f"{job_id}.srt")


### PR DESCRIPTION
## Summary

`process_transcribe_media` in `services/v1/media/media_transcribe.py` raises `UnboundLocalError` whenever a caller asks for cloud-mode output without text.

The `else` branch at line 137 assigns `text_file = None` (wrong name), but line 153 returns `text_filename`. In the common case of `include_text=True` the bug is hidden because the `if` branch assigns `text_filename` for real. The moment you disable `include_text` in cloud mode, Python bails out with:

```
cannot access local variable 'text_filename' where it is not associated with a value
```

## Reproduction

```bash
POST /v1/media/transcribe
{
  "media_url": "https://.../speech.mp3",
  "response_type": "cloud",
  "include_text": false,
  "include_srt": true
}
```

The job is queued, Whisper transcribes, then the upload step explodes with the UnboundLocalError above and the job is marked failed.

## Fix

One-line typo fix — bind `text_filename = None` in the `else` branch so the return statement sees a defined name.

```diff
             else:
-                text_file = None
+                text_filename = None
```

## Test plan

- [x] Reproduced the error against `upstream/main` (`d9bb567`) using SRT-only cloud mode.
- [x] After the fix, the same request completes, the SRT is uploaded, and the webhook returns `{ srt_url, text_url: null, segments_url: null }` as expected.
- [x] `include_text=True` path still behaves identically (the `if` branch was already correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)